### PR TITLE
#36 Navbar 레이아웃 및 라우트 설정

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,14 +6,20 @@ import DetailPage from "./pages/DetailPage.jsx";
 import MyPage from "./pages/MyPage.jsx";
 import SuperUserPage from "./pages/SuperUserPage.jsx";
 import TestRouteArray from "./testRoutes/";
+import Layout from "./package/layout/Layout.jsx";
 
 const ProductRouteArray = [
-    { path: "/", element: <FrontPage /> },
-    { path: "/detail", element: <DetailPage /> },
-    { path: "/mypage", element: <MyPage /> },
-    { path: "/super-user", element: <SuperUserPage /> },
+  {
+    path: "/", 
+    element: <Layout />,
+    children: [
+      { path: "/", element: <FrontPage /> },
+      { path: "/detail", element: <DetailPage /> },
+      { path: "/mypage", element: <MyPage /> },
+      { path: "/super-user", element: <SuperUserPage /> },
+    ],
+  },
 ];
-
 const routeArray = [...ProductRouteArray, ...TestRouteArray];
 
 const router = createBrowserRouter(routeArray);

--- a/src/package/layout/Layout.jsx
+++ b/src/package/layout/Layout.jsx
@@ -1,0 +1,40 @@
+import { Outlet } from "react-router";
+import { Link } from "react-router"; 
+import CustomInput from "../CustomInput";
+import styles from "../../pages/FrontPage.module.css";
+
+const Layout = () => {
+  const handleSearch = () => {
+    // 검색 처리 로직
+  };
+
+  return (
+    <>
+      <nav className={styles.navbar}>
+        <div className={styles.logo}>
+          <Link to="/">Logo</Link>
+        </div>
+
+        <div className={styles.search}>
+          <CustomInput
+            placeholder="검색어를 입력해주세요"
+            onEnter={handleSearch}
+            style={{ width: "100%" }}
+          />
+        </div>
+
+        <ul className={styles.navList}>
+          <li>
+            <Link to="/mypage">마이페이지</Link>
+          </li>
+        </ul>
+
+        <button className={styles.loginButton}>로그인</button>
+      </nav>
+
+      <Outlet />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/testRoutes/_mijinTestRoutes.jsx
+++ b/src/testRoutes/_mijinTestRoutes.jsx
@@ -1,5 +1,5 @@
 import MijinTestPage from "./testPages/mijin/MijinTestPage";
 
 export const MijinTestRouteArray = [
-    { path: "/test/mijin", element: <MijinTestPage /> },
+  { path: "/test/mijin", element: <MijinTestPage /> },
 ];


### PR DESCRIPTION
### 작업 내용
- 기존 FrontPage.jsx에 있던 Navbar를 Layout.jsx로 분리
- Outlet 적용
- main.jsx에서 라우트 설정 변경
- 테스트 라우트(MijinTestRouteArray) 추가 (확인 작업 했습니다..) 

### 확인 방법
- `/` 접속 시 Layout + FrontPage 표시
- `/mypage` 접속 시 Layout + MyPage 표시