### PR TITLE
#68 공통 컴포넌트 FlexOneContainer 만들기

### DIFF
--- a/src/package/flexOneContainer/FlexOneContainer.jsx
+++ b/src/package/flexOneContainer/FlexOneContainer.jsx
@@ -1,5 +1,9 @@
 import styles from "./FlexOneContainer.module.css";
 
+/**
+ * @param {boolean} isYScrollable - `isYScrollable` === `isYScrollable={true}`
+ * @param {boolean} isXScrollable - `isXScrollable` === `isXScrollable={true}`
+ */
 const FlexOneContainer = ({
     isYScrollable,
     isXScrollable,

--- a/src/package/flexOneContainer/FlexOneContainer.jsx
+++ b/src/package/flexOneContainer/FlexOneContainer.jsx
@@ -3,7 +3,6 @@ import styles from "./FlexOneContainer.module.css";
 const FlexOneContainer = ({
     isYScrollable,
     isXScrollable,
-    isPaddedForScrollbar,
     style,
     className,
     children,
@@ -12,8 +11,6 @@ const FlexOneContainer = ({
     const flexOneStyle = {};
     flexOneStyle["--overflow-x"] = isXScrollable ? "scroll" : "hidden";
     flexOneStyle["--overflow-y"] = isYScrollable ? "scroll" : "hidden";
-    flexOneStyle["--pr"] =
-        isYScrollable && isPaddedForScrollbar ? "var(--sizing-mx)" : undefined;
     return (
         <div
             {...props}

--- a/src/package/flexOneContainer/FlexOneContainer.jsx
+++ b/src/package/flexOneContainer/FlexOneContainer.jsx
@@ -1,0 +1,28 @@
+import styles from "./FlexOneContainer.module.css";
+
+const FlexOneContainer = ({
+    isYScrollable,
+    isXScrollable,
+    isPaddedForScrollbar,
+    style,
+    className,
+    children,
+    ...props
+}) => {
+    const flexOneStyle = {};
+    flexOneStyle["--overflow-x"] = isXScrollable ? "scroll" : "hidden";
+    flexOneStyle["--overflow-y"] = isYScrollable ? "scroll" : "hidden";
+    flexOneStyle["--pr"] =
+        isYScrollable && isPaddedForScrollbar ? "var(--sizing-mx)" : undefined;
+    return (
+        <div
+            {...props}
+            style={{ ...flexOneStyle, ...style }}
+            className={`${styles.flexOne} ${className}`}
+        >
+            {children}
+        </div>
+    );
+};
+
+export default FlexOneContainer;

--- a/src/package/flexOneContainer/FlexOneContainer.module.css
+++ b/src/package/flexOneContainer/FlexOneContainer.module.css
@@ -1,0 +1,6 @@
+.flexOne {
+    flex: 1;
+    overflow-x: var(--overflow-x);
+    overflow-y: var(--overflow-y);
+    padding-right: var(--pr);
+}

--- a/src/package/flexOneContainer/FlexOneContainer.module.css
+++ b/src/package/flexOneContainer/FlexOneContainer.module.css
@@ -2,5 +2,4 @@
     flex: 1;
     overflow-x: var(--overflow-x);
     overflow-y: var(--overflow-y);
-    padding-right: var(--pr);
 }

--- a/src/testRoutes/testPages/thepott/ThePottTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottTestPage.jsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import CustomButton from "../../../package/customButton/CustomButton.jsx";
 import Skeleton from "../../../package/skeleton/Skeleton.jsx";
-import { Vstack } from "../../../package/layout/";
+import { Hstack, Vstack } from "../../../package/layout/";
 import Calendar from "../../../package/calendar/Calendar.jsx";
 import Modal from "../../../package/modal/Modal.jsx";
+import FlexOneContainer from "../../../package/flexOneContainer/FlexOneContainer.jsx";
 
 const ThePottTestPage = () => {
     const [isOn, setIsOn] = useState(false);
@@ -34,6 +35,37 @@ const ThePottTestPage = () => {
                 <span>something</span>
                 <span>something</span>
             </Vstack>
+            <Hstack style={{ height: "200px" }}>
+                <div
+                    style={{
+                        width: "200px",
+                        height: "200px",
+                        backgroundColor: "var(--color-red)",
+                    }}
+                >
+                    sidebar
+                </div>
+                <FlexOneContainer
+                    style={{ backgroundColor: "var(--color-blue)" }}
+                    isYScrollable
+                >
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                    <p>여기에 아무거나 있다고 치고</p>
+                </FlexOneContainer>
+            </Hstack>
             <Vstack center>
                 <Skeleton widthInPixel={600} heightInPixel={100} />
                 <CustomButton>shape="RECTANGLE" - 기본값</CustomButton>


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷
<img width="1917" height="321" alt="image" src="https://github.com/user-attachments/assets/ee83f26a-499e-4fde-b174-c74dde47c4f8" />


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
1. flex container의 자식이 남은 공간을 모두 차지하되, 스크롤이 가능하게 하는 컴포넌트입니다.
2. 속성을 추가해 스크롤을 가능하게 할 수 있습니다.
    기본값: hidden
    예: `<FlexOneContainer isYScrollable>{...}</FlexOneContainer>`
3. jsdoc을 추가해두었습니다. 호출한 `FlexOneContainer` 위에 마우스를 가져다 대면 설명을 볼 수 있습니다
<img width="1800" height="315" alt="image" src="https://github.com/user-attachments/assets/e8542f88-f3b9-4ce6-9059-ac7db961da8d" />

