### PR TITLE
#162 소속사 페이지__아티스트 mutate 이후 로컬에 반영

### DIFF
--- a/src/features/agency/agencyComponents/AgencyArtistModal.jsx
+++ b/src/features/agency/agencyComponents/AgencyArtistModal.jsx
@@ -52,12 +52,12 @@ const AgencyArtistModal = () => {
     const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
     const modalKey = useLinkUpStore((state) => state.modalKey);
     const setModalKey = useLinkUpStore((state) => state.setModalKey);
+
     const addArtistInTemp = useLinkUpStore((state) => state.addArtistInTemp);
+    const addArtistInReal = useLinkUpStore((state) => state.addArtistInReal);
+
     const updateArtistInTemp = useLinkUpStore(
         (state) => state.updateArtistInTemp,
-    );
-    const replaceArtistWithResponse = useLinkUpStore(
-        (state) => state.replaceArtistWithResponse,
     );
     const deleteArtist = useLinkUpStore((state) => state.deleteArtist);
 
@@ -73,23 +73,18 @@ const AgencyArtistModal = () => {
         onMutate: (formData) => {
             addArtistInTemp(formData);
         },
-        // onMutate: (formData) => addArtistInTemp(formData),
-        // onSuccess: (data) => replaceArtistWithResponse(data),
+        onSuccess: (data) => addArtistInReal(data),
     });
     const putMutation = useMutation({
-        mutationFn: async ({ body, id }) => {
-            const data = await axiosReturnsData(
+        mutationFn: async ({ body, id }) =>
+            axiosReturnsData(
                 "PUT",
                 `/api/companies/artists/with-images/${id}`,
                 body,
-            );
-            debugger;
-            return data;
-        },
+            ),
         onMutate: ({ id, body }) => {
             updateArtistInTemp(id, body);
         },
-        onSuccess: (data) => replaceArtistWithResponse(data),
     });
     const deleteMutation = useMutation({
         mutationFn: (id) => {

--- a/src/features/agency/agencyComponents/AgencyArtistModal.jsx
+++ b/src/features/agency/agencyComponents/AgencyArtistModal.jsx
@@ -1,13 +1,11 @@
 import styles from "./AgencyArtistModal.module.css";
-import { useMutation } from "@tanstack/react-query";
 import CustomButton from "../../../package/customButton/CustomButton";
 import CustomInput from "../../../package/CustomInput";
 import GridContainer from "../../../package/gridContainer/GridContainer";
 import { Vstack } from "../../../package/layout";
 import Modal from "../../../package/modal/Modal";
 import useLinkUpStore from "../../../shared/store/store";
-import { axiosReturnsData } from "../../../shared/services/axiosInstance";
-import { useAgentArtistModal } from "../agencyServices/useAgency";
+import useAgentArtistModal from "../agencyServices/useAgencyArtistModal";
 import { useRef } from "react";
 import ImageInput from "../../../package/imageInput/ImageInput";
 import RoundBox from "../../../package/RoundBox";
@@ -53,45 +51,8 @@ const AgencyArtistModal = () => {
     const modalKey = useLinkUpStore((state) => state.modalKey);
     const setModalKey = useLinkUpStore((state) => state.setModalKey);
 
-    const addArtistInTemp = useLinkUpStore((state) => state.addArtistInTemp);
-    const addArtistInReal = useLinkUpStore((state) => state.addArtistInReal);
-
-    const updateArtistInTemp = useLinkUpStore(
-        (state) => state.updateArtistInTemp,
-    );
-    const deleteArtist = useLinkUpStore((state) => state.deleteArtist);
-
-    const { isPending, error } = useAgentArtistModal();
-
-    const postMutation = useMutation({
-        mutationFn: (formData) =>
-            axiosReturnsData(
-                "POST",
-                "/api/companies/artists/with-images",
-                formData,
-            ),
-        onMutate: (formData) => {
-            addArtistInTemp(formData);
-        },
-        onSuccess: (data) => addArtistInReal(data),
-    });
-    const putMutation = useMutation({
-        mutationFn: async ({ body, id }) =>
-            axiosReturnsData(
-                "PUT",
-                `/api/companies/artists/with-images/${id}`,
-                body,
-            ),
-        onMutate: ({ id, body }) => {
-            updateArtistInTemp(id, body);
-        },
-    });
-    const deleteMutation = useMutation({
-        mutationFn: (id) => {
-            return axiosReturnsData("DELETE", `/api/companies/artists/${id}`);
-        },
-        onMutate: (id) => deleteArtist(id),
-    });
+    const { isPending, error, postMutation, putMutation, deleteMutation } =
+        useAgentArtistModal();
 
     const handleDismiss = () => {
         setModalKey(null);

--- a/src/features/agency/agencyComponents/AgencyArtistModal.jsx
+++ b/src/features/agency/agencyComponents/AgencyArtistModal.jsx
@@ -115,7 +115,6 @@ const AgencyArtistModal = () => {
             isOn={modalKey === "agencySidebar"}
             onBackgroundClick={handleDismiss}
         >
-            <RoundBox>{selectedArtist?.id ?? "null"}</RoundBox>
             <form ref={formRef} onSubmit={handleSubmit}>
                 <GridContainer gap="MD" cols={4}>
                     <Vstack>

--- a/src/features/agency/agencyComponents/AgencyCalendar.jsx
+++ b/src/features/agency/agencyComponents/AgencyCalendar.jsx
@@ -1,7 +1,7 @@
 import Calendar from "../../../package/calendar/Calendar";
 import RoundBox from "../../../package/RoundBox";
 import useLinkUpStore from "../../../shared/store/store";
-import { useAgencyCalendar } from "../agencyServices/useAgency";
+import useAgencyCalendar from "../agencyServices/useAgencyCalendar";
 import styles from "./AgencyCalendar.module.css";
 import AgencyCalendarModal from "./AgencyCalendarModal";
 

--- a/src/features/agency/agencyComponents/AgencySidebar.jsx
+++ b/src/features/agency/agencyComponents/AgencySidebar.jsx
@@ -47,13 +47,6 @@ const AgencySidebar = () => {
         (state) => state.setSelectedArtist,
     );
     const artistArray = useLinkUpStore((state) => state.artistArray);
-    const groupArray = artistArray.filter(
-        (artist) => artist.artist_type === "group",
-    );
-
-    const individualArray = artistArray.filter(
-        (artist) => artist.artist_type === "individual",
-    );
 
     const handleAdd = () => {
         setSelectedArtist(null);
@@ -64,17 +57,8 @@ const AgencySidebar = () => {
         <>
             <AgencyArtistModal />
             <Vstack className={styles.sidebar}>
-                {groupArray.map((group) => (
-                    <ArtistButton
-                        key={`${group.group_name}__${group.stage_name}`}
-                        artist={group}
-                    />
-                ))}
-                {individualArray.map((individual) => (
-                    <ArtistButton
-                        key={individual.stage_name}
-                        artist={individual}
-                    />
+                {artistArray.map((artist) => (
+                    <ArtistButton key={artist.stage_name} artist={artist} />
                 ))}
                 <CustomButton isOn={true} onClick={handleAdd}>
                     추가

--- a/src/features/agency/agencyServices/agencyApi.js
+++ b/src/features/agency/agencyServices/agencyApi.js
@@ -1,9 +1,0 @@
-import axiosInstance from "../../../shared/services/axiosInstance";
-import useLinkUpStore from "../../../shared/store/store";
-
-export const getCompaniesArtists = async () => {
-    const response = await axiosInstance.get("/api/companies/artists");
-    const data = response.data;
-    useLinkUpStore.setState({ artistArray: data });
-    return data;
-};

--- a/src/features/agency/agencyServices/useAgency.js
+++ b/src/features/agency/agencyServices/useAgency.js
@@ -1,22 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCompaniesArtists } from "./agencyApi";
 import { useEffect } from "react";
-import { axiosReturnsData } from "../../../package/commonServices/axiosVariants";
+import { axiosReturnsData } from "../../../shared/services/axiosInstance";
 import useLinkUpStore from "../../../shared/store/store";
 
-export const useAgency = () => {
-    // data is stored right after fetch
-    const { isPending, error } = useQuery({
-        queryKey: ["companiesArtists"],
-        queryFn: () => getCompaniesArtists(),
+const useAgency = () => {
+    const setArtistArray = useLinkUpStore((state) => state.setArtistArray);
+    const { data, isPending, error } = useQuery({
+        queryKey: ["/api/companies/artists"],
+        queryFn: () => axiosReturnsData("GET", "/api/companies/artists"),
     });
 
     useEffect(() => {
-        if (!error) {
+        if (!data) {
             return;
         }
-        console.error(error);
-    }, [error]);
+        setArtistArray(data);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data]);
 
     return {
         error,
@@ -24,54 +24,4 @@ export const useAgency = () => {
     };
 };
 
-export const useAgencyCalendar = () => {
-    const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
-    const { isPending, error, refetch } = useQuery({
-        queryKey: ["companiesEvent", selectedArtist?.id ?? -1],
-        queryFn: async () => {
-            const data = await axiosReturnsData(
-                "GET",
-                `/api/companies/events?artist_id=${selectedArtist?.id ?? -1}`,
-            );
-            // const eventArray = data.map((event) => ({
-            //     ...event,
-            //     start_time: new Date(event.start_time),
-            //     end_time: new Date(event.end_time),
-            // }));
-            useLinkUpStore.setState({ eventArray: data });
-            return data;
-        },
-        refetchOnWindowFocus: false,
-        enabled: false,
-    });
-    useEffect(() => {
-        if (!selectedArtist) {
-            return;
-        }
-        refetch();
-    }, [selectedArtist]);
-
-    return { isPending, error };
-};
-
-export const useAgentArtistModal = () => {
-    const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
-    const artistId = selectedArtist?.id ?? -1;
-    const { isPending, error } = useQuery({
-        queryKey: [`/api/companies/artists/`, artistId],
-        queryFn: async () => {
-            if (artistId === -1) {
-                return null;
-            }
-            const selectedArtist = useLinkUpStore.getState().selectedArtist;
-            const data = await axiosReturnsData(
-                "GET",
-                `/api/companies/artists/${selectedArtist?.id ?? -1}`,
-            );
-            useLinkUpStore.setState({ selectedArtist: data });
-            return data;
-        },
-    });
-
-    return { isPending, error };
-};
+export default useAgency;

--- a/src/features/agency/agencyServices/useAgency.js
+++ b/src/features/agency/agencyServices/useAgency.js
@@ -56,7 +56,6 @@ export const useAgencyCalendar = () => {
 
 export const useAgentArtistModal = () => {
     const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
-    console.log({ selectedArtist, yaho: "siiick" });
     const artistId = selectedArtist?.id ?? -1;
     const { isPending, error } = useQuery({
         queryKey: [`/api/companies/artists/`, artistId],

--- a/src/features/agency/agencyServices/useAgencyArtistModal.js
+++ b/src/features/agency/agencyServices/useAgencyArtistModal.js
@@ -1,0 +1,85 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { axiosReturnsData } from "../../../package/commonServices/axiosVariants";
+import useLinkUpStore from "../../../shared/store/store";
+import { useEffect } from "react";
+
+const useAgentArtistModalQuery = () => {
+    const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
+    const setSelectedArtist = useLinkUpStore(
+        (state) => state.setSelectedArtist,
+    );
+
+    const artistId = selectedArtist?.id ?? -1;
+    const { data, isPending, error } = useQuery({
+        queryKey: [`/api/companies/artists/${artistId}`],
+        queryFn: async () => {
+            if (artistId === -1) {
+                return null;
+            }
+            const data = await axiosReturnsData(
+                "GET",
+                `/api/companies/artists/${selectedArtist?.id ?? -1}`,
+            );
+            return data;
+        },
+    });
+
+    useEffect(() => {
+        if (!data) {
+            return;
+        }
+        setSelectedArtist(data);
+    }, [data]);
+
+    return { isPending, error };
+};
+
+const useAgentArtistModalMutate = () => {
+    const addArtistInTemp = useLinkUpStore((state) => state.addArtistInTemp);
+    const addArtistInReal = useLinkUpStore((state) => state.addArtistInReal);
+    const updateArtistInTemp = useLinkUpStore(
+        (state) => state.updateArtistInTemp,
+    );
+    const deleteArtist = useLinkUpStore((state) => state.deleteArtist);
+
+    const postMutation = useMutation({
+        mutationFn: (formData) =>
+            axiosReturnsData(
+                "POST",
+                "/api/companies/artists/with-images",
+                formData,
+            ),
+        onMutate: (formData) => {
+            addArtistInTemp(formData);
+        },
+        onSuccess: (data) => addArtistInReal(data),
+    });
+    const putMutation = useMutation({
+        mutationFn: async ({ body, id }) =>
+            axiosReturnsData(
+                "PUT",
+                `/api/companies/artists/with-images/${id}`,
+                body,
+            ),
+        onMutate: ({ id, body }) => {
+            updateArtistInTemp(id, body);
+        },
+    });
+    const deleteMutation = useMutation({
+        mutationFn: (id) => {
+            return axiosReturnsData("DELETE", `/api/companies/artists/${id}`);
+        },
+        onMutate: (id) => deleteArtist(id),
+    });
+
+    return { postMutation, putMutation, deleteMutation };
+};
+
+const useAgentArtistModal = () => {
+    const queryReturn = useAgentArtistModalQuery();
+    const mutateReturn = useAgentArtistModalMutate();
+
+    return { ...queryReturn, ...mutateReturn };
+};
+
+export default useAgentArtistModal;

--- a/src/features/agency/agencyServices/useAgencyCalendar.js
+++ b/src/features/agency/agencyServices/useAgencyCalendar.js
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { axiosReturnsData } from "../../../package/commonServices/axiosVariants";
+import useLinkUpStore from "../../../shared/store/store";
+
+const useAgencyCalendarQuery = () => {
+    const setEventArray = useLinkUpStore((state) => state.setEventArray);
+    const selectedArtist = useLinkUpStore((state) => state.selectedArtist);
+
+    const { data, isPending, error, refetch } = useQuery({
+        queryKey: [
+            `/api/companies/events?artist_id=${selectedArtist?.id ?? -1}`,
+        ],
+        queryFn: () =>
+            axiosReturnsData(
+                "GET",
+                `/api/companies/events?artist_id=${selectedArtist?.id ?? -1}`,
+            ),
+        refetchOnWindowFocus: false,
+        enabled: false,
+    });
+
+    useEffect(() => {
+        if (!data) {
+            return;
+        }
+        setEventArray(data);
+    }, [data]);
+
+    useEffect(() => {
+        if (!selectedArtist) {
+            return;
+        }
+        refetch();
+    }, [selectedArtist]);
+
+    return { isPending, error };
+};
+
+const useAgencyCalendar = () => {
+    const queryReturn = useAgencyCalendarQuery();
+
+    return { ...queryReturn };
+};
+
+export default useAgencyCalendar;

--- a/src/features/agency/agencyUtils.js
+++ b/src/features/agency/agencyUtils.js
@@ -1,0 +1,9 @@
+export const convertFormDataToArtist = (formData) => {
+    const artist = {
+        stage_name: formData.get("stage_name"),
+        group_name: formData.get("group_name"),
+        debut_date: formData.get("debut_date"),
+        birth_date: formData.get("birth_date"),
+    };
+    return artist;
+};

--- a/src/package/imageInput/ImageInput.jsx
+++ b/src/package/imageInput/ImageInput.jsx
@@ -1,6 +1,7 @@
 import styles from "./ImageInput.module.css";
 import { useEffect, useRef, useState } from "react";
 import RoundBox from "../RoundBox";
+import CustomButton from "../customButton/CustomButton";
 
 const PLACEHOLDER_IMAGE =
     "https://plus.unsplash.com/premium_photo-1738592736106-a17b897c0ab1?q=80&w=1267&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";

--- a/src/pages/AgencyPage.jsx
+++ b/src/pages/AgencyPage.jsx
@@ -6,7 +6,6 @@ import useLinkUpStore from "../shared/store/store.js";
 const AgencyPage = () => {
     const { error, isLoading } = useAgency();
     const artistArray = useLinkUpStore((state) => state.artistArray);
-    console.log({ artistArray });
 
     return (
         <>

--- a/src/pages/AgencyPage.jsx
+++ b/src/pages/AgencyPage.jsx
@@ -1,11 +1,9 @@
 import AgencyContent from "../features/agency/agencyComponents/AgencyContent.jsx";
 import AgencySkeleton from "../features/agency/agencyComponents/AgencySkeleton.jsx";
-import { useAgency } from "../features/agency/agencyServices/useAgency.js";
-import useLinkUpStore from "../shared/store/store.js";
+import useAgency from "../features/agency/agencyServices/useAgency.js";
 
 const AgencyPage = () => {
     const { error, isLoading } = useAgency();
-    const artistArray = useLinkUpStore((state) => state.artistArray);
 
     return (
         <>

--- a/src/shared/store/store.js
+++ b/src/shared/store/store.js
@@ -96,9 +96,9 @@ const useLinkUpStore = create()(
                 );
                 set({ artistArray });
             },
-            deleteArtist: (artist) => {
+            deleteArtist: (id) => {
                 const artistArray = get().artistArray.filter(
-                    (el) => el.id !== artist.id,
+                    (artist) => artist.id !== id,
                 );
                 set({ artistArray });
             },

--- a/src/shared/store/store.js
+++ b/src/shared/store/store.js
@@ -51,6 +51,21 @@ const useLinkUpStore = create()(
                 const artistArray = [...get().artistArray, artist];
                 set({ artistArray });
             },
+            addArtistInReal: (data) => {
+                const {
+                    artist_id: id,
+                    artist_name,
+                    message: _message,
+                    ...rest
+                } = data;
+
+                const artistArray = get().artistArray.map((artist) =>
+                    artist.stage_name === artist_name
+                        ? { ...artist, id, ...rest }
+                        : artist,
+                );
+                set({ artistArray });
+            },
             updateArtistInTemp: (artistId, formData) => {
                 const updatedArtist = {
                     stage_name: formData.get("stage_name"),
@@ -66,11 +81,19 @@ const useLinkUpStore = create()(
                 );
                 set({ artistArray });
             },
-            replaceArtistWithResponse: (responseData) => {
-                const filteredArtistArray = get().artistArray.filter(
-                    (artist) => artist.id,
+            updateArtistInReal: (data) => {
+                const {
+                    artist_id,
+                    artist_name: stage_name,
+                    message: _message,
+                    ...rest
+                } = data;
+
+                const artistArray = get().artistArray.map((artist) =>
+                    artist.id === artist_id
+                        ? { ...artist, stage_name, ...rest }
+                        : artist,
                 );
-                const artistArray = [...filteredArtistArray, responseData];
                 set({ artistArray });
             },
             deleteArtist: (artist) => {

--- a/src/shared/store/store.js
+++ b/src/shared/store/store.js
@@ -42,10 +42,10 @@ const useLinkUpStore = create()(
             },
             addArtistInTemp: (formData) => {
                 const artist = {
-                    stage_name: formData.getName("stage_name"),
-                    group_name: formData.getName("group_name"),
-                    debut_date: formData.getName("debut_date"),
-                    birth_date: formData.getName("birth_date"),
+                    stage_name: formData.get("stage_name"),
+                    group_name: formData.get("group_name"),
+                    debut_date: formData.get("debut_date"),
+                    birth_date: formData.get("birth_date"),
                 };
 
                 const artistArray = [...get().artistArray, artist];
@@ -53,10 +53,10 @@ const useLinkUpStore = create()(
             },
             updateArtistInTemp: (artistId, formData) => {
                 const updatedArtist = {
-                    stage_name: formData.getName("stage_name"),
-                    group_name: formData.getName("group_name"),
-                    debut_date: formData.getName("debut_date"),
-                    birth_date: formData.getName("birth_date"),
+                    stage_name: formData.get("stage_name"),
+                    group_name: formData.get("group_name"),
+                    debut_date: formData.get("debut_date"),
+                    birth_date: formData.get("birth_date"),
                 };
 
                 const artistArray = get().artistArray.map((artist) =>

--- a/src/shared/store/store.js
+++ b/src/shared/store/store.js
@@ -40,18 +40,43 @@ const useLinkUpStore = create()(
             setArtistArray: (artistArray) => {
                 set({ artistArray });
             },
-            addArtist: (artist) => {
-                const artistArray = [...get().artist, artist];
+            addArtistInTemp: (formData) => {
+                const artist = {
+                    stage_name: formData.getName("stage_name"),
+                    group_name: formData.getName("group_name"),
+                    debut_date: formData.getName("debut_date"),
+                    birth_date: formData.getName("birth_date"),
+                };
+
+                const artistArray = [...get().artistArray, artist];
                 set({ artistArray });
             },
-            deleteArtist: (artist) => {
-                const artistArray = get().artist.filter(
-                    (el) => el.id !== artist.id,
+            updateArtistInTemp: (artistId, formData) => {
+                const updatedArtist = {
+                    stage_name: formData.getName("stage_name"),
+                    group_name: formData.getName("group_name"),
+                    debut_date: formData.getName("debut_date"),
+                    birth_date: formData.getName("birth_date"),
+                };
+
+                const artistArray = get().artistArray.map((artist) =>
+                    artist.id === artistId
+                        ? { ...artist, ...updatedArtist }
+                        : artist,
                 );
                 set({ artistArray });
             },
-            clearTempArtist: () => {
-                const artistArray = get().artist.filter((artist) => artist.id);
+            replaceArtistWithResponse: (responseData) => {
+                const filteredArtistArray = get().artistArray.filter(
+                    (artist) => artist.id,
+                );
+                const artistArray = [...filteredArtistArray, responseData];
+                set({ artistArray });
+            },
+            deleteArtist: (artist) => {
+                const artistArray = get().artistArray.filter(
+                    (el) => el.id !== artist.id,
+                );
                 set({ artistArray });
             },
 

--- a/src/shared/store/store.js
+++ b/src/shared/store/store.js
@@ -5,58 +5,68 @@ const useLinkUpStore = create()(
     persist(
         (set, get) => ({
             something: 1,
-            setSomething(diff) {
+            setSomething: (diff) => {
                 const state = get();
                 const newSomething = state.something + diff;
                 set({ something: newSomething });
             },
 
             access_token: null,
-            setAccessToken(access_token) {
+            setAccessToken: (access_token) => {
                 set({ access_token });
             },
 
             user: null,
-            setUser(user) {
+            setUser: (user) => {
                 set({ user });
             },
 
-            isModalOn: false,
-            setIsModalOn(isModalOn) {
-                set({ isModalOn });
-            },
-
             modalKey: null,
-            setModalKey(modalKey) {
+            setModalKey: (modalKey) => {
                 set({ modalKey });
             },
 
             selectedArtist: null,
-            setSelectedArtist(selectedArtist) {
+            setSelectedArtist: (selectedArtist) => {
                 set({ selectedArtist });
             },
 
             eventArray: [],
-            setEventArray(eventArray) {
+            setEventArray: (eventArray) => {
                 set({ eventArray });
             },
 
             artistArray: [],
-            setArtistArray(artistArray) {
+            setArtistArray: (artistArray) => {
+                set({ artistArray });
+            },
+            addArtist: (artist) => {
+                const artistArray = [...get().artist, artist];
+                set({ artistArray });
+            },
+            deleteArtist: (artist) => {
+                const artistArray = get().artist.filter(
+                    (el) => el.id !== artist.id,
+                );
+                set({ artistArray });
+            },
+            clearTempArtist: () => {
+                const artistArray = get().artist.filter((artist) => artist.id);
                 set({ artistArray });
             },
 
             selectedEvent: null,
-            setSelectedEvent(selectedEvent) {
+            setSelectedEvent: (selectedEvent) => {
                 set({ selectedEvent });
             },
 
             //dummyMijin.js
-            groupArray: [], 
+            groupArray: [],
             setGroupArray: (groupArray) => set({ groupArray }),
 
             recommendedGroupArray: [],
-            setRecommendedGroupArray: (arr) => set({ recommendedGroupArray: arr }),
+            setRecommendedGroupArray: (arr) =>
+                set({ recommendedGroupArray: arr }),
 
             searchResultArray: [],
             setSearchResultArray: (arr) => set({ searchResultArray: arr }),
@@ -69,7 +79,11 @@ const useLinkUpStore = create()(
                 set((state) => {
                     const current = state.subscribedArtistIdArray;
                     return current.includes(artistId)
-                        ? { subscribedArtistIdArray: current.filter((id) => id !== artistId) }
+                        ? {
+                              subscribedArtistIdArray: current.filter(
+                                  (id) => id !== artistId,
+                              ),
+                          }
                         : { subscribedArtistIdArray: [...current, artistId] };
                 }),
         }),
@@ -80,8 +94,8 @@ const useLinkUpStore = create()(
                 access_token: state.access_token,
                 user: state.user,
             }),
-        }
-    )
+        },
+    ),
 );
 
 export default useLinkUpStore;


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷

<img width="543" height="245" alt="image" src="https://github.com/user-attachments/assets/73075000-65df-484c-bfa2-02912124817a" />

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
1. 서비스 후크는 호출되는 파일별로의 파일로 분리
2. 탠스택 쿼리가 관리하는 캐시를 저스탠드 스토어에 저장
3. 낙관적 업데이트는 쿼리의 캐시를 기준으로 시행