### PR TITLE
#234 회원가입 페이지__UI 수파베이스처럼 만들기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "oz_main_linkup_front",
             "version": "0.0.0",
             "dependencies": {
+                "@hookform/resolvers": "^5.2.2",
                 "@tanstack/react-query": "^5.89.0",
                 "axios": "^1.12.2",
                 "date-fns": "^4.1.0",
@@ -15,6 +16,7 @@
                 "react-dom": "^19.1.0",
                 "react-hook-form": "^7.63.0",
                 "react-router": "^7.8.2",
+                "zod": "^4.1.11",
                 "zustand": "^5.0.8"
             },
             "devDependencies": {
@@ -907,6 +909,18 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@hookform/resolvers": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+            "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/utils": "^0.3.0"
+            },
+            "peerDependencies": {
+                "react-hook-form": "^7.55.0"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1309,6 +1323,12 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
         },
         "node_modules/@tanstack/query-core": {
             "version": "5.89.0",
@@ -3165,6 +3185,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+            "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zustand": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "date-fns": "^4.1.0",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
+                "react-hook-form": "^7.63.0",
                 "react-router": "^7.8.2",
                 "zustand": "^5.0.8"
             },
@@ -2792,6 +2793,22 @@
             },
             "peerDependencies": {
                 "react": "^19.1.1"
+            }
+        },
+        "node_modules/react-hook-form": {
+            "version": "7.63.0",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+            "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "format": "prettier --write --cache ."
     },
     "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.89.0",
         "axios": "^1.12.2",
         "date-fns": "^4.1.0",
@@ -19,6 +20,7 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.63.0",
         "react-router": "^7.8.2",
+        "zod": "^4.1.11",
         "zustand": "^5.0.8"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "date-fns": "^4.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.63.0",
         "react-router": "^7.8.2",
         "zustand": "^5.0.8"
     },

--- a/src/features/front/search/SearchContent.jsx
+++ b/src/features/front/search/SearchContent.jsx
@@ -13,8 +13,11 @@ const SearchContent = () => {
     const [searchParams] = useSearchParams();
     const queryParam = searchParams.get("query") || "";
 
+    // const groupArray = useLinkUpStore((state) => state.groupArray);
     const setGroupArray = useLinkUpStore((state) => state.setGroupArray);
+    const recommendedGroupArray = useLinkUpStore((state) => state.recommendedGroupArray);
     const setRecommendedGroupArray = useLinkUpStore((state) => state.setRecommendedGroupArray);
+    const searchResultArray = useLinkUpStore((state) => state.searchResultArray);
     const setSearchResultArray = useLinkUpStore((state) => state.setSearchResultArray);
 
     const eventArray = useLinkUpStore((state) => state.eventArray);
@@ -32,7 +35,7 @@ const SearchContent = () => {
 
                     if (artist.artist_type === "individual" && artist.group_name) {
                         const groupRes = await fetch(
-                            `http://3.35.210.2:8000/api/idol/${artist.group_name}`
+                            `http://3.35.210.2:8000/api/idol/${artist.group_name}`,
                         );
                         const groupData = await groupRes.json();
                         setSearchResultArray([groupData]);
@@ -41,11 +44,11 @@ const SearchContent = () => {
                     } else {
                         setSearchResultArray([artist]);
                         await fetchEvents({ artist_id: artist.id });
-                        await fetchFanPosts(artist.id); 
+                        await fetchFanPosts(artist.id);
                     }
                 } else {
                     const res = await fetch(
-                        "http://3.35.210.2:8000/api/idol?artist_type=group&limit=20&page=1"
+                        "http://3.35.210.2:8000/api/idol?artist_type=group&limit=20&page=1",
                     );
                     const data = await res.json();
                     const artists = data.artists || [];
@@ -65,7 +68,7 @@ const SearchContent = () => {
                 const query = new URLSearchParams({
                     limit: 20,
                     is_active: true,
-                    ...params
+                    ...params,
                 }).toString();
                 const res = await fetch(`http://3.35.210.2:8000/events/?${query}`);
                 const data = await res.json();
@@ -85,7 +88,7 @@ const SearchContent = () => {
                 const posts = data.map((post) => ({
                     postId: post.id,
                     imgUrl: post.image_url ?? "",
-                    likes: post.likes_count
+                    likes: post.likes_count,
                 }));
                 setFanPostArray(posts);
             } catch (err) {
@@ -171,3 +174,4 @@ const SearchContent = () => {
 };
 
 export default SearchContent;
+

--- a/src/features/layout/Navbar.jsx
+++ b/src/features/layout/Navbar.jsx
@@ -6,14 +6,6 @@ import CustomButton from "../../package/customButton/CustomButton";
 import useLinkUpStore from "../../shared/store/store";
 import useAuth from "../../shared/services/useAuth";
 
-const DebugButton = () => {
-    const access_token = useLinkUpStore((state) => state.access_token);
-    const user = useLinkUpStore((state) => state.user);
-    const handleClick = () => {
-        console.log({ access_token, user });
-    };
-    return <CustomButton onClick={handleClick}>DEBUG</CustomButton>;
-};
 const SideSection = ({ justify, children, ...props }) => (
     <Hstack justify={justify} className={styles.sideSection} {...props}>
         {children}
@@ -62,7 +54,6 @@ const Navbar = () => {
     return (
         <Hstack justify="center" items="center">
             <Hstack items="center" justify="space-between" className={styles.navbar}>
-                <DebugButton />
                 <SideSection justify="start">
                     <Link to="/" className={styles.logo}>
                         Logo

--- a/src/features/layout/Navbar.module.css
+++ b/src/features/layout/Navbar.module.css
@@ -12,6 +12,7 @@
 .logo {
     font-weight: bold;
     color: var(--color-vivid);
+    text-decoration: none;
 }
 
 .searchbar {

--- a/src/features/signup/signupInputProps.js
+++ b/src/features/signup/signupInputProps.js
@@ -1,3 +1,6 @@
+/** label을 사용한 뒤 나머지를 쉽게 spread 하려면 애초에 둘이 분리되어야 하고
+ * 이를 제일 쉽게 하는 법은 dict의 key value로 나누는 것이다
+ */
 export const inputPropsDict = {
     이메일: {
         name: "email",

--- a/src/features/signup/signupInputProps.js
+++ b/src/features/signup/signupInputProps.js
@@ -20,20 +20,6 @@ export const inputPropsDict = {
         pattern: "^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).*$",
         title: "소문자, 대문자, 특수문자를 하나 이상 씩 써주세요",
     },
-    "비밀번호 확인": {
-        name: "passwordConfirm",
-        type: "password",
-        autoComplete: "off",
-    },
-    "핸드폰 번호": {
-        name: "phone_number",
-        type: "tel",
-        autoComplete: "tel",
-        minLength: 4,
-        maxLength: 20,
-        pattern: "^[0-9]{4,20}$",
-        title: "- 없이 숫자만 입력하세요",
-    },
     닉네임: {
         name: "nickname",
         type: "text",

--- a/src/package/CustomInput.module.css
+++ b/src/package/CustomInput.module.css
@@ -8,6 +8,10 @@
     font-size: var(--text-md);
 }
 
+.input:hover {
+    border-color: var(--color-dim);
+}
+
 .input:focus {
     border-color: var(--color-dim);
 }

--- a/src/package/labelGroup/LabelGroup.jsx
+++ b/src/package/labelGroup/LabelGroup.jsx
@@ -1,0 +1,33 @@
+import styles from "./LabelGroup.module.css";
+import { Vstack } from "../layout";
+
+const BigLabel = ({ className, children, ...props }) => {
+    return (
+        <p {...props} className={`${styles.bigLabel} ${className}`}>
+            {children}
+        </p>
+    );
+};
+const SmallLabel = ({ className, children, ...props }) => {
+    return (
+        <p {...props} className={`${styles.smallLabel} ${className}`}>
+            {children}
+        </p>
+    );
+};
+
+const LabelGroup = ({ isRed, style, children }) => {
+    const styleForVar = {};
+    styleForVar["--color"] = isRed ? "var(--color-red)" : "var(--color-muted)";
+
+    return (
+        <Vstack style={{ ...styleForVar, ...style }} className={styles.container} gap="none">
+            {children}
+        </Vstack>
+    );
+};
+
+LabelGroup.BigLabel = BigLabel;
+LabelGroup.SmallLabel = SmallLabel;
+
+export default LabelGroup;

--- a/src/package/labelGroup/LabelGroup.module.css
+++ b/src/package/labelGroup/LabelGroup.module.css
@@ -1,0 +1,13 @@
+.bigLabel {
+    font-size: var(--text-md);
+    font-weight: var(--font-weight-semibold);
+}
+
+.smallLabel {
+    font-size: var(--text-sm);
+}
+
+.container {
+    color: var(--color);
+    text-align: start;
+}

--- a/src/package/layout/_Vstack.jsx
+++ b/src/package/layout/_Vstack.jsx
@@ -15,7 +15,7 @@ const BaseVstack = ({
     const vstackStyle = {};
     vstackStyle["--justify"] = justify;
     vstackStyle["--items"] = items;
-    vstackStyle["--gap"] = `var(--spacing-${gap})`;
+    vstackStyle["--gap"] = gap === "non" ? 0 : `var(--spacing-${gap})`;
 
     return (
         <div

--- a/src/package/layout/_Vstack.jsx
+++ b/src/package/layout/_Vstack.jsx
@@ -1,5 +1,4 @@
 import CenterInRow from "./_CenterInRow";
-import { gapToClassName, spacingToCssVar } from "./layoutUtils";
 import styles from "./_Vstack.module.css";
 
 const BaseVstack = ({
@@ -12,18 +11,17 @@ const BaseVstack = ({
     ...props
 }) => {
     const defaultClassName = styles.vstack;
-    const gapClassName = gapToClassName[gap];
 
     const vstackStyle = {};
     vstackStyle["--justify"] = justify;
     vstackStyle["--items"] = items;
-    vstackStyle["--gap"] = spacingToCssVar[gap];
+    vstackStyle["--gap"] = `var(--spacing-${gap})`;
 
     return (
         <div
             {...props}
             style={{ ...vstackStyle, ...style }}
-            className={`${defaultClassName} ${gapClassName} ${className}`}
+            className={`${defaultClassName}  ${className}`}
         >
             {children}
         </div>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -28,7 +28,7 @@ const LoginPage = () => {
                 <Vstack gap="xl">
                     <Vstack style={{ width: "400px" }}>
                         <form onSubmit={handleSubmit}>
-                            <Vstack>
+                            <Vstack gap="xl">
                                 {loginInputPropsEntryArray.map((entry) => (
                                     <CustomInputLabeled
                                         key={entry[0]}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,8 +1,10 @@
+import styles from "./LoginPage.module.css";
+import { Link } from "react-router";
 import SocialLoginButton from "../features/login/loginComponents/SocialLoginButton";
 import { loginInputPropsEntryArray } from "../features/login/loginServices/loginInputProps";
 import CustomButton from "../package/customButton/CustomButton";
 import CustomInputLabeled from "../package/CustomInputLabeled";
-import { FullScreen, Vstack } from "../package/layout";
+import { FullScreen, Hstack, Vstack } from "../package/layout";
 import RoundBox from "../package/RoundBox";
 import useAuth from "../shared/services/useAuth";
 
@@ -44,6 +46,13 @@ const LoginPage = () => {
                         <SocialLoginButton provider={"KAKAO"} />
                         <SocialLoginButton provider={"FACEBOOK"} />
                     </Vstack>
+
+                    <Hstack>
+                        <p className={styles.smallSubText}>계정이 필요한가요?</p>
+                        <Link to="/signup" className={styles.smallLink}>
+                            가입하기
+                        </Link>
+                    </Hstack>
                 </Vstack>
             </RoundBox>
         </FullScreen>

--- a/src/pages/LoginPage.module.css
+++ b/src/pages/LoginPage.module.css
@@ -1,0 +1,10 @@
+.smallSubText {
+    color: var(--color-muted);
+    font-size: var(--text-sm);
+}
+
+.smallLink {
+    color: var(--color-blue);
+    font-size: var(--text-sm);
+    text-decoration: none;
+}

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -10,6 +10,7 @@ import {
     checkAdditionalEmailValidity,
     checkAdditionalPasswordValidity,
 } from "../features/signup/signupCheckValidity";
+import FlexOneContainer from "../package/flexOneContainer/FlexOneContainer";
 
 const SignupPage = () => {
     const [isForAgency, setIsForAgency] = useState(false);
@@ -66,54 +67,58 @@ const SignupPage = () => {
     const verifyEmailButtonLabel = verifiedEmail ? "인증 완료" : "이메일 인증";
 
     return (
-        <FullScreen center>
-            <RoundBox padding="LG">
-                <Vstack center>
-                    <Hstack gap="none">
-                        <CustomButton
-                            isOn={!isForAgency}
-                            className={styles.grow}
-                            onClick={() => setIsForAgency(false)}
-                        >
-                            팬
-                        </CustomButton>
-                        <CustomButton
-                            isOn={isForAgency}
-                            className={styles.grow}
-                            onClick={() => setIsForAgency(true)}
-                        >
-                            소속사
-                        </CustomButton>
-                    </Hstack>
+        <div className={styles.container}>
+            <RoundBox padding="XL">
+                <form onSubmit={handleSubmit}>
+                    <Vstack center gap="lg">
+                        <Hstack gap="none">
+                            <CustomButton
+                                isOn={!isForAgency}
+                                className={styles.grow}
+                                onClick={() => setIsForAgency(false)}
+                                type="button"
+                            >
+                                팬
+                            </CustomButton>
+                            <CustomButton
+                                isOn={isForAgency}
+                                className={styles.grow}
+                                onClick={() => setIsForAgency(true)}
+                                type="button"
+                            >
+                                소속사
+                            </CustomButton>
+                        </Hstack>
 
-                    <form onSubmit={handleSubmit}>
-                        <Vstack style={{ width: "400px" }}>
-                            <Hstack style={{ width: "100%" }} items="end">
-                                <CustomInputLabeled
-                                    label="이메일"
-                                    vstackProps={{ className: styles.grow }}
-                                    inputProps={{
-                                        ref: emailRef,
-                                        ...inputPropsDict["이메일"],
-                                    }}
-                                />
-                                <CustomButton type="button" onClick={handleVerificationClick}>
-                                    {verifyEmailButtonLabel}
-                                </CustomButton>
-                            </Hstack>
-                            {inputPropsEntryArray.slice(1).map((entry) => (
-                                <CustomInputLabeled
-                                    key={entry[0]}
-                                    label={entry[0]}
-                                    inputProps={entry[1]}
-                                />
-                            ))}
-                            <CustomButton>회원가입</CustomButton>
-                        </Vstack>
-                    </form>
-                </Vstack>
+                        <Hstack style={{ width: "100%" }} items="end">
+                            <CustomInputLabeled
+                                label="이메일"
+                                vstackProps={{ className: styles.grow }}
+                                inputProps={{
+                                    ref: emailRef,
+                                    ...inputPropsDict["이메일"],
+                                }}
+                            />
+                            <CustomButton
+                                type="button"
+                                onClick={handleVerificationClick}
+                                className={styles.certificateButton}
+                            >
+                                {verifyEmailButtonLabel}
+                            </CustomButton>
+                        </Hstack>
+                        {inputPropsEntryArray.slice(1).map((entry) => (
+                            <CustomInputLabeled
+                                key={entry[0]}
+                                label={entry[0]}
+                                inputProps={entry[1]}
+                            />
+                        ))}
+                        <CustomButton>회원가입</CustomButton>
+                    </Vstack>
+                </form>
             </RoundBox>
-        </FullScreen>
+        </div>
     );
 };
 

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,7 +1,7 @@
 import styles from "./SignupPage.module.css";
 import { useState } from "react";
 import RoundBox from "../package/RoundBox";
-import { FullScreen, Hstack, Vstack } from "../package/layout";
+import { Hstack, Vstack } from "../package/layout";
 import CustomButton from "../package/customButton/CustomButton";
 import CustomInputLabeled from "../package/CustomInputLabeled";
 import { useSignup } from "../features/signup/useSignup";
@@ -10,21 +10,13 @@ import {
     checkAdditionalEmailValidity,
     checkAdditionalPasswordValidity,
 } from "../features/signup/signupCheckValidity";
-import FlexOneContainer from "../package/flexOneContainer/FlexOneContainer";
 import LabelGroup from "../package/labelGroup/LabelGroup";
 import CustomInput from "../package/CustomInput";
 
 const SignupPage = () => {
     const [isForAgency, setIsForAgency] = useState(false);
 
-    const {
-        verifiedEmail,
-        setVerifiedEmail,
-        emailRef,
-        refetchVerification,
-        setBody,
-        refetchSignup,
-    } = useSignup();
+    const { verifiedEmail, setVerifiedEmail, emailRef, refetchVerification, setBody } = useSignup();
 
     const handleVerificationClick = () => {
         if (!emailRef.current) {
@@ -109,17 +101,12 @@ const SignupPage = () => {
                                 {verifyEmailButtonLabel}
                             </CustomButton>
                         </Hstack>
-                        <LabelGroup>
-                            <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
-                            <CustomInput />
-                            <LabelGroup.SmallLabel>올바르지 않은 형식입니다</LabelGroup.SmallLabel>
-                        </LabelGroup>
                         {inputPropsEntryArray.slice(1).map((entry) => (
-                            <CustomInputLabeled
-                                key={entry[0]}
-                                label={entry[0]}
-                                inputProps={entry[1]}
-                            />
+                            <LabelGroup>
+                                <LabelGroup.BigLabel>{entry[0]}</LabelGroup.BigLabel>
+                                <CustomInput {...entry[1]} />
+                                <LabelGroup.SmallLabel></LabelGroup.SmallLabel>
+                            </LabelGroup>
                         ))}
                         <CustomButton>회원가입</CustomButton>
                     </Vstack>

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -11,6 +11,8 @@ import {
     checkAdditionalPasswordValidity,
 } from "../features/signup/signupCheckValidity";
 import FlexOneContainer from "../package/flexOneContainer/FlexOneContainer";
+import LabelGroup from "../package/labelGroup/LabelGroup";
+import CustomInput from "../package/CustomInput";
 
 const SignupPage = () => {
     const [isForAgency, setIsForAgency] = useState(false);
@@ -107,6 +109,11 @@ const SignupPage = () => {
                                 {verifyEmailButtonLabel}
                             </CustomButton>
                         </Hstack>
+                        <LabelGroup>
+                            <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
+                            <CustomInput />
+                            <LabelGroup.SmallLabel>올바르지 않은 형식입니다</LabelGroup.SmallLabel>
+                        </LabelGroup>
                         {inputPropsEntryArray.slice(1).map((entry) => (
                             <CustomInputLabeled
                                 key={entry[0]}

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -5,10 +5,7 @@ import { FullScreen, Hstack, Vstack } from "../package/layout";
 import CustomButton from "../package/customButton/CustomButton";
 import CustomInputLabeled from "../package/CustomInputLabeled";
 import { useSignup } from "../features/signup/useSignup";
-import {
-    inputPropsDict,
-    inputPropsEntryArray,
-} from "../features/signup/signupInputProps";
+import { inputPropsDict, inputPropsEntryArray } from "../features/signup/signupInputProps";
 import {
     checkAdditionalEmailValidity,
     checkAdditionalPasswordValidity,
@@ -41,20 +38,10 @@ const SignupPage = () => {
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        const {
-            email,
-            verification_code,
-            password,
-            passwordConfirm,
-            phone_number,
-            nickname,
-        } = event.target;
+        const { email, verification_code, password, passwordConfirm, phone_number, nickname } =
+            event.target;
 
-        const isEmailValid = checkAdditionalEmailValidity(
-            verifiedEmail,
-            email,
-            setVerifiedEmail,
-        );
+        const isEmailValid = checkAdditionalEmailValidity(verifiedEmail, email, setVerifiedEmail);
         if (!isEmailValid) {
             return;
         }
@@ -64,14 +51,11 @@ const SignupPage = () => {
             password: password.value,
             phone_number: phone_number.value,
             nickname: nickname.value,
-            user_type: "fan",
+            user_type: isForAgency ? "company" : "fan",
             verification_code: verification_code.value,
         };
 
-        const isPasswordValid = checkAdditionalPasswordValidity(
-            password,
-            passwordConfirm,
-        );
+        const isPasswordValid = checkAdditionalPasswordValidity(password, passwordConfirm);
         if (!isPasswordValid) {
             return;
         }
@@ -113,10 +97,7 @@ const SignupPage = () => {
                                         ...inputPropsDict["이메일"],
                                     }}
                                 />
-                                <CustomButton
-                                    type="button"
-                                    onClick={handleVerificationClick}
-                                >
+                                <CustomButton type="button" onClick={handleVerificationClick}>
                                     {verifyEmailButtonLabel}
                                 </CustomButton>
                             </Hstack>

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -12,9 +12,20 @@ import {
 } from "../features/signup/signupCheckValidity";
 import LabelGroup from "../package/labelGroup/LabelGroup";
 import CustomInput from "../package/CustomInput";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { signupSchema } from "../shared/validations/zodSchema";
 
 const SignupPage = () => {
     const [isForAgency, setIsForAgency] = useState(false);
+
+    const [isPasswordFocused, setIsPasswordFocused] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm({ resolver: zodResolver(signupSchema) });
 
     const { verifiedEmail, setVerifiedEmail, emailRef, refetchVerification, setBody } = useSignup();
 
@@ -31,39 +42,22 @@ const SignupPage = () => {
         refetchVerification();
     };
 
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        const { email, verification_code, password, passwordConfirm, phone_number, nickname } =
-            event.target;
+    const onSubmit = (data) => {
+        const body = { ...data, user_type: isForAgency ? "company" : "fan" };
 
-        const isEmailValid = checkAdditionalEmailValidity(verifiedEmail, email, setVerifiedEmail);
-        if (!isEmailValid) {
-            return;
-        }
-
-        const tempBody = {
-            email: email.value,
-            password: password.value,
-            phone_number: phone_number.value,
-            nickname: nickname.value,
-            user_type: isForAgency ? "company" : "fan",
-            verification_code: verification_code.value,
-        };
-
-        const isPasswordValid = checkAdditionalPasswordValidity(password, passwordConfirm);
-        if (!isPasswordValid) {
-            return;
-        }
-
-        setBody(tempBody);
+        setBody(body);
     };
 
     const verifyEmailButtonLabel = verifiedEmail ? "인증 완료" : "이메일 인증";
+    const passwordLabel =
+        isPasswordFocused || errors.password
+            ? "비밀번호 - 8자 이상, 대소문자, 특수문자 필수"
+            : "비밀번호";
 
     return (
         <div className={styles.container}>
             <RoundBox padding="XL">
-                <form onSubmit={handleSubmit}>
+                <form onSubmit={handleSubmit(onSubmit)}>
                     <Vstack center gap="lg">
                         <Hstack gap="none">
                             <CustomButton
@@ -85,14 +79,15 @@ const SignupPage = () => {
                         </Hstack>
 
                         <Hstack style={{ width: "100%" }} items="end">
-                            <CustomInputLabeled
-                                label="이메일"
-                                vstackProps={{ className: styles.grow }}
-                                inputProps={{
-                                    ref: emailRef,
-                                    ...inputPropsDict["이메일"],
-                                }}
-                            />
+                            <LabelGroup isRed={errors.email}>
+                                <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
+                                <CustomInput {...register("email")} />
+                                {errors.email && (
+                                    <LabelGroup.SmallLabel>
+                                        {errors.email.message}
+                                    </LabelGroup.SmallLabel>
+                                )}
+                            </LabelGroup>
                             <CustomButton
                                 type="button"
                                 onClick={handleVerificationClick}
@@ -101,13 +96,47 @@ const SignupPage = () => {
                                 {verifyEmailButtonLabel}
                             </CustomButton>
                         </Hstack>
-                        {inputPropsEntryArray.slice(1).map((entry) => (
-                            <LabelGroup>
-                                <LabelGroup.BigLabel>{entry[0]}</LabelGroup.BigLabel>
-                                <CustomInput {...entry[1]} />
-                                <LabelGroup.SmallLabel></LabelGroup.SmallLabel>
-                            </LabelGroup>
-                        ))}
+                        <LabelGroup isRed={errors.verification_code}>
+                            <LabelGroup.BigLabel>인증 번호</LabelGroup.BigLabel>
+                            <CustomInput {...register("verification_code")} />
+                            {errors.verification_code && (
+                                <LabelGroup.SmallLabel>
+                                    {errors.verification_code.message}
+                                </LabelGroup.SmallLabel>
+                            )}
+                        </LabelGroup>
+                        <LabelGroup isRed={errors.password}>
+                            <LabelGroup.BigLabel>{passwordLabel}</LabelGroup.BigLabel>
+                            <CustomInput
+                                {...register("password")}
+                                type="password"
+                                onFocus={() => setIsPasswordFocused(true)}
+                                onBlur={() => setIsPasswordFocused(false)}
+                            />
+                            {errors.password && (
+                                <LabelGroup.SmallLabel>
+                                    {errors.password.message}
+                                </LabelGroup.SmallLabel>
+                            )}
+                        </LabelGroup>
+                        <LabelGroup isRed={errors.passwordConfirm}>
+                            <LabelGroup.BigLabel>비밀번호 확인</LabelGroup.BigLabel>
+                            <CustomInput {...register("passwordConfirm")} type="password" />
+                            {errors.passwordConfirm && (
+                                <LabelGroup.SmallLabel>
+                                    {errors.passwordConfirm.message}
+                                </LabelGroup.SmallLabel>
+                            )}
+                        </LabelGroup>
+                        <LabelGroup isRed={errors.nickname}>
+                            <LabelGroup.BigLabel>닉네임</LabelGroup.BigLabel>
+                            <CustomInput {...register("nickname")} />
+                            {errors.nickname && (
+                                <LabelGroup.SmallLabel>
+                                    {errors.nickname.message}
+                                </LabelGroup.SmallLabel>
+                            )}
+                        </LabelGroup>
                         <CustomButton>회원가입</CustomButton>
                     </Vstack>
                 </form>

--- a/src/pages/SignupPage.module.css
+++ b/src/pages/SignupPage.module.css
@@ -1,3 +1,15 @@
+.container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .grow {
     flex-grow: 1;
+}
+
+.certificateButton {
+    padding: var(--spacing-md);
 }

--- a/src/shared/utils/validation.js
+++ b/src/shared/utils/validation.js
@@ -1,0 +1,33 @@
+export const inputNameToValidationProps = {
+    email: {
+        type: "email",
+        autoComplete: "email",
+        maxLength: 200,
+        required: true,
+    },
+    verification_code: {
+        type: "text",
+        autoComplete: "off",
+        required: true,
+    },
+    password: {
+        type: "password",
+        autoComplete: "new-password",
+        minLength: 8,
+        maxLength: 200,
+        pattern: "^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).*$",
+        title: "소문자, 대문자, 특수문자를 하나 이상 씩 써주세요",
+        required: true,
+    },
+    passwordConfirm: {
+        type: "password",
+        autoComplete: "off",
+        required: true,
+    },
+    nickname: {
+        type: "text",
+        autoComplete: "off",
+        minLength: 2,
+        required: true,
+    },
+};

--- a/src/shared/validations/zodSchema.js
+++ b/src/shared/validations/zodSchema.js
@@ -19,4 +19,14 @@ export const signupSchema = z
         path: ["passwordConfirm"],
     });
 
-export const passwordChangeSchema = z.object({});
+export const passwordChangeSchema = z.object({
+    oldPassword: z.string().min(1, "기존 비밀번호를 입력하세요"),
+    password: z
+        .string()
+        .min(8, "8자 이상을 입력해주세요")
+        .regex(
+            /^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).*$/,
+            "대문자, 소문자, 특수문자가 하나 이상 씩 필요합니다",
+        ),
+    passwordConfirm: z.string().min(1, "비밀번호를 한 번 더 입력하세요"),
+});

--- a/src/shared/validations/zodSchema.js
+++ b/src/shared/validations/zodSchema.js
@@ -1,0 +1,22 @@
+import z from "zod";
+
+export const signupSchema = z
+    .object({
+        email: z.email("올바르지 않은 이메일 형식입니다"),
+        verification_code: z.string().min(1, "메일로 받은 인증 코드를 입력해주세요"),
+        password: z
+            .string()
+            .min(8, "8자 이상을 입력해주세요")
+            .regex(
+                /^(?=.*[a-z])(?=.*[A-Z])(?=.*[^a-zA-Z0-9]).*$/,
+                "대문자, 소문자, 특수문자가 하나 이상 씩 필요합니다",
+            ),
+        passwordConfirm: z.string().min(1, "비밀번호를 한 번 더 입력하세요"),
+        nickname: z.string().min(2, "2자 이상을 입력해주세요"),
+    })
+    .refine((data) => data.password === data.passwordConfirm, {
+        message: "비밀번호가 일치하지 않습니다",
+        path: ["passwordConfirm"],
+    });
+
+export const passwordChangeSchema = z.object({});

--- a/src/testRoutes/_thepottTestRoutes.jsx
+++ b/src/testRoutes/_thepottTestRoutes.jsx
@@ -1,7 +1,9 @@
 import ThePottApiTestPage from "./testPages/thepott/ThePottApiTestPage";
+import ThePottFormTestPage from "./testPages/thepott/ThePottFormTestPage";
 import ThePottTestPage from "./testPages/thepott/ThePottTestPage";
 
 export const ThePottTestRouteArray = [
     { path: "/test/thepott", element: <ThePottTestPage /> },
     { path: "/test/thepott/api", element: <ThePottApiTestPage /> },
+    { path: "/test/thepott/form", element: <ThePottFormTestPage /> },
 ];

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -1,0 +1,5 @@
+const ThePottFormTestPage = () => {
+    return <div>test page</div>;
+};
+
+export default ThePottFormTestPage;

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -2,17 +2,20 @@ import { useForm } from "react-hook-form";
 import CustomInput from "../../../package/CustomInput";
 import CustomButton from "../../../package/customButton/CustomButton";
 import LabelGroup from "../../../package/labelGroup/LabelGroup";
+import { inputNameToValidationProps } from "../../../shared/utils/validation";
 
 const TutorialForm = () => {
     const {
         register,
         handleSubmit,
-        watch,
         formState: { errors },
     } = useForm();
-    const onSubmit = (data) => console.log(data);
-
-    console.log(watch("example")); // watch input value by passing the name of it
+    const onSubmit = (data) => {
+        console.log({ data });
+        if (errors) {
+            console.log({ errors });
+        }
+    };
 
     return (
         /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
@@ -20,7 +23,7 @@ const TutorialForm = () => {
             {/* register your input into the hook by invoking the "register" function */}
             <LabelGroup>
                 <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
-                <CustomInput {...register("email")} />
+                <CustomInput {...register("email", { type: "email", minLength: 100 })} />
                 {errors.email && (
                     <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
                 )}
@@ -28,28 +31,28 @@ const TutorialForm = () => {
             <LabelGroup>
                 <LabelGroup.BigLabel>인증 번호</LabelGroup.BigLabel>
                 <CustomInput {...register("verification_code")} />
-                {errors.email && (
+                {errors.verification_code && (
                     <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
             <LabelGroup>
                 <LabelGroup.BigLabel>비밀번호</LabelGroup.BigLabel>
                 <CustomInput {...register("password")} />
-                {errors.email && (
+                {errors.password && (
                     <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
             <LabelGroup>
                 <LabelGroup.BigLabel>비밀번호 확인</LabelGroup.BigLabel>
                 <CustomInput {...register("passwordConfirm")} />
-                {errors.email && (
+                {errors.passwordConfirm && (
                     <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
             <LabelGroup>
                 <LabelGroup.BigLabel>닉네임</LabelGroup.BigLabel>
                 <CustomInput {...register("nickname")} />
-                {errors.email && (
+                {errors.nickname && (
                     <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -2,14 +2,15 @@ import { useForm } from "react-hook-form";
 import CustomInput from "../../../package/CustomInput";
 import CustomButton from "../../../package/customButton/CustomButton";
 import LabelGroup from "../../../package/labelGroup/LabelGroup";
-import { inputNameToValidationProps } from "../../../shared/utils/validation";
+import { signupSchema } from "../../../shared/validations/zodSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const TutorialForm = () => {
     const {
         register,
         handleSubmit,
         formState: { errors },
-    } = useForm();
+    } = useForm({ resolver: zodResolver(signupSchema) });
     const onSubmit = (data) => {
         console.log({ data });
         if (errors) {
@@ -21,39 +22,41 @@ const TutorialForm = () => {
         /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
         <form onSubmit={handleSubmit(onSubmit)}>
             {/* register your input into the hook by invoking the "register" function */}
-            <LabelGroup>
+            <LabelGroup isRed={errors.email}>
                 <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
-                <CustomInput {...register("email", { type: "email", minLength: 100 })} />
+                <CustomInput {...register("email")} />
                 {errors.email && (
-                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                    <LabelGroup.SmallLabel>{errors.email.message}</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
-            <LabelGroup>
+            <LabelGroup isRed={errors.verification_code}>
                 <LabelGroup.BigLabel>인증 번호</LabelGroup.BigLabel>
                 <CustomInput {...register("verification_code")} />
                 {errors.verification_code && (
-                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                    <LabelGroup.SmallLabel>
+                        {errors.verification_code.message}
+                    </LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
-            <LabelGroup>
+            <LabelGroup isRed={errors.password}>
                 <LabelGroup.BigLabel>비밀번호</LabelGroup.BigLabel>
                 <CustomInput {...register("password")} />
                 {errors.password && (
-                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                    <LabelGroup.SmallLabel>{errors.password.message}</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
-            <LabelGroup>
+            <LabelGroup isRed={errors.passwordConfirm}>
                 <LabelGroup.BigLabel>비밀번호 확인</LabelGroup.BigLabel>
                 <CustomInput {...register("passwordConfirm")} />
                 {errors.passwordConfirm && (
-                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                    <LabelGroup.SmallLabel>{errors.passwordConfirm.message}</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
-            <LabelGroup>
+            <LabelGroup isRed={errors.nickname}>
                 <LabelGroup.BigLabel>닉네임</LabelGroup.BigLabel>
                 <CustomInput {...register("nickname")} />
                 {errors.nickname && (
-                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                    <LabelGroup.SmallLabel>{errors.nickname.message}</LabelGroup.SmallLabel>
                 )}
             </LabelGroup>
 

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -50,6 +50,7 @@ const TutorialForm = () => {
                 <LabelGroup.BigLabel>{passwordLabel}</LabelGroup.BigLabel>
                 <CustomInput
                     {...register("password")}
+                    type="password"
                     onFocus={() => setIsPasswordFocused(true)}
                     onBlur={() => setIsPasswordFocused(false)}
                 />
@@ -59,7 +60,7 @@ const TutorialForm = () => {
             </LabelGroup>
             <LabelGroup isRed={errors.passwordConfirm}>
                 <LabelGroup.BigLabel>비밀번호 확인</LabelGroup.BigLabel>
-                <CustomInput {...register("passwordConfirm")} />
+                <CustomInput {...register("passwordConfirm")} type="password" />
                 {errors.passwordConfirm && (
                     <LabelGroup.SmallLabel>{errors.passwordConfirm.message}</LabelGroup.SmallLabel>
                 )}

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -1,5 +1,70 @@
+import { useForm } from "react-hook-form";
+import CustomInput from "../../../package/CustomInput";
+import CustomButton from "../../../package/customButton/CustomButton";
+import LabelGroup from "../../../package/labelGroup/LabelGroup";
+
+const TutorialForm = () => {
+    const {
+        register,
+        handleSubmit,
+        watch,
+        formState: { errors },
+    } = useForm();
+    const onSubmit = (data) => console.log(data);
+
+    console.log(watch("example")); // watch input value by passing the name of it
+
+    return (
+        /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
+        <form onSubmit={handleSubmit(onSubmit)}>
+            {/* register your input into the hook by invoking the "register" function */}
+            <LabelGroup>
+                <LabelGroup.BigLabel>이메일</LabelGroup.BigLabel>
+                <CustomInput {...register("email")} />
+                {errors.email && (
+                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                )}
+            </LabelGroup>
+            <LabelGroup>
+                <LabelGroup.BigLabel>인증 번호</LabelGroup.BigLabel>
+                <CustomInput {...register("verification_code")} />
+                {errors.email && (
+                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                )}
+            </LabelGroup>
+            <LabelGroup>
+                <LabelGroup.BigLabel>비밀번호</LabelGroup.BigLabel>
+                <CustomInput {...register("password")} />
+                {errors.email && (
+                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                )}
+            </LabelGroup>
+            <LabelGroup>
+                <LabelGroup.BigLabel>비밀번호 확인</LabelGroup.BigLabel>
+                <CustomInput {...register("passwordConfirm")} />
+                {errors.email && (
+                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                )}
+            </LabelGroup>
+            <LabelGroup>
+                <LabelGroup.BigLabel>닉네임</LabelGroup.BigLabel>
+                <CustomInput {...register("nickname")} />
+                {errors.email && (
+                    <LabelGroup.SmallLabel>This field is required</LabelGroup.SmallLabel>
+                )}
+            </LabelGroup>
+
+            <CustomButton>submit</CustomButton>
+        </form>
+    );
+};
+
 const ThePottFormTestPage = () => {
-    return <div>test page</div>;
+    return (
+        <div>
+            <TutorialForm />
+        </div>
+    );
 };
 
 export default ThePottFormTestPage;

--- a/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottFormTestPage.jsx
@@ -4,8 +4,11 @@ import CustomButton from "../../../package/customButton/CustomButton";
 import LabelGroup from "../../../package/labelGroup/LabelGroup";
 import { signupSchema } from "../../../shared/validations/zodSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
 
 const TutorialForm = () => {
+    const [isPasswordFocused, setIsPasswordFocused] = useState(false);
+
     const {
         register,
         handleSubmit,
@@ -17,6 +20,11 @@ const TutorialForm = () => {
             console.log({ errors });
         }
     };
+
+    const passwordLabel =
+        isPasswordFocused || errors.password
+            ? "비밀번호 - 8자 이상, 대소문자, 특수문자 필수"
+            : "비밀번호";
 
     return (
         /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
@@ -39,8 +47,12 @@ const TutorialForm = () => {
                 )}
             </LabelGroup>
             <LabelGroup isRed={errors.password}>
-                <LabelGroup.BigLabel>비밀번호</LabelGroup.BigLabel>
-                <CustomInput {...register("password")} />
+                <LabelGroup.BigLabel>{passwordLabel}</LabelGroup.BigLabel>
+                <CustomInput
+                    {...register("password")}
+                    onFocus={() => setIsPasswordFocused(true)}
+                    onBlur={() => setIsPasswordFocused(false)}
+                />
                 {errors.password && (
                     <LabelGroup.SmallLabel>{errors.password.message}</LabelGroup.SmallLabel>
                 )}


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷
<img width="480" height="738" alt="image" src="https://github.com/user-attachments/assets/628d6835-8941-4a26-99c6-bd33a8055ba5" />


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. zod, react-hook-form 이용해서 유효성 검사 단순화
2. 테스트 페이지에 적용 `/test/thepott/form`
3. 회원가입 페이지에 적용