### PR TITLE
#187 프론트 페이지 아닌 페이지에서 검색 시 검색 페이지로 넘어가지 않는 버그 해결

### DIFF
--- a/src/features/layout/Navbar.jsx
+++ b/src/features/layout/Navbar.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useSearchParams } from "react-router";
+import { Link, useLocation, useNavigate, useSearchParams } from "react-router";
 import styles from "./Navbar.module.css";
 import CustomInput from "../../package/CustomInput";
 import { Hstack } from "../../package/layout";
@@ -41,6 +41,7 @@ const MyButton = ({ user }) => {
 };
 
 const Navbar = () => {
+    const location = useLocation();
     const navigate = useNavigate();
     const [, setSearchParams] = useSearchParams();
     const user = useLinkUpStore((state) => state.user);
@@ -48,6 +49,15 @@ const Navbar = () => {
 
     const handleSearch = (keyword) => {
         const trimmed = keyword.trim();
+        if (!trimmed) {
+            return;
+        }
+
+        const pathname = location.pathname;
+        if (pathname !== "/") {
+            navigate("/");
+        }
+
         setSearchParams({ query: trimmed });
     };
 

--- a/src/testRoutes/testPages/thepott/ThePottTanstackTestPage.jsx
+++ b/src/testRoutes/testPages/thepott/ThePottTanstackTestPage.jsx
@@ -19,9 +19,13 @@ const ThePottTanstackTestPage = () => {
 
     const firstIdol = idolArray.find((idol) => idol.id === 1);
 
-    const variables = {
+    const variablesAespa = {
         body: { artist_id: 1 },
-        newOne: { artist_id: 1, stage_name: firstIdol.name, group_name: firstIdol.name },
+        newOne: { artist_id: 1, stage_name: firstIdol?.name, group_name: firstIdol?.name },
+    };
+    const variablesKarina = {
+        body: { artist_id: 6 },
+        newOne: { artist_id: 6, stage_name: "카리나", group_name: "에스파" },
     };
 
     useEffect(() => {
@@ -38,12 +42,18 @@ const ThePottTanstackTestPage = () => {
             <p>subscribing artist array</p>
             {artistArray.map((artist) => (
                 <p>
-                    {artist.stage_name || artist.group_name}__{artist.id}
+                    {artist.stage_name || artist.group_name}__{artist.artist_id}
                 </p>
             ))}
             <CustomButton onClick={() => deleteMutation.mutate(1)}>unsubscribe idol 1</CustomButton>
-            <CustomButton onClick={() => postMutation.mutate(variables)}>
+            <CustomButton onClick={() => postMutation.mutate(variablesAespa)}>
                 subscribe idol 1
+            </CustomButton>
+            <CustomButton onClick={() => postMutation.mutate(variablesKarina)}>
+                subscribe karina (6)
+            </CustomButton>
+            <CustomButton onClick={() => deleteMutation.mutate(6)}>
+                unsubscribe karina (6)
             </CustomButton>
         </Vstack>
     );


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷

<img width="736" height="590" alt="image" src="https://github.com/user-attachments/assets/136efeb1-1577-4e11-bd0d-3988cd7d99ca" />


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 검색창에서 엔터 누를 때, 현재 주소 확인, `/` 아니면 거기로 이동함
2. 검색어 없을 땐 아무 일도 안 일어나게 함 ---- 유튜브 따라함