### PR TITLE
#280 세부페이지__배너 이미지 연결 및 팬포스트 이동/구독 버튼 색상 개선 

### DIFF
--- a/src/features/detail/DetailContent.jsx
+++ b/src/features/detail/DetailContent.jsx
@@ -115,7 +115,7 @@ const DetailContent = () => {
                 <div className={styles.buttonRight}>
                     <CustomButton
                         shape="RECTANGLE"
-                        color={isSubscribed ? "MONO" : "PRIMARY"}
+                        color= "MONO"
                         isOn
                         onClick={() => setModalKey("subscribeModal")}
                     >

--- a/src/features/detail/DetailContent.jsx
+++ b/src/features/detail/DetailContent.jsx
@@ -11,6 +11,7 @@ import CustomImageBanner from "../../shared/CustomImageBanner/CustomImageBanner"
 import { axiosReturnsData } from "../../shared/services/axiosInstance";
 import FanPostGrid from "../../shared/FanPostGrid";
 import ArtistCalendar from "../../shared/ArtistCalendar/ArtistCalendar";
+import MyFanPostModal from "../mypage/MyFanPostModal";
 
 const getSubscriptions = async () => {
     const data = await axiosReturnsData("GET", "/api/subscriptions/?include_image=true");
@@ -164,6 +165,8 @@ const DetailContent = () => {
                     <CustomButton onClick={() => setModalKey(null)}>취소</CustomButton>
                 </div>
             </Modal>
+            
+            <MyFanPostModal />
         </div>
     );
 };

--- a/src/features/detail/DetailContent.jsx
+++ b/src/features/detail/DetailContent.jsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router";
-import { useEffect, useRef } from "react"; 
+import { useEffect, useRef } from "react";
 import useLinkUpStore from "../../shared/store/store";
 import CustomButton from "../../package/customButton/CustomButton.jsx";
 import Modal from "../../package/modal/Modal.jsx";
@@ -36,7 +36,6 @@ const DetailContent = () => {
     const setModalKey = useLinkUpStore((state) => state.setModalKey);
 
     const isSubscribed = artistArray.some((a) => a.id === Number(id));
-
     const currentArtist = artistArray.find((a) => a.id === Number(id));
     const imageUrl = currentArtist?.banner_url || currentArtist?.artist_image_url;
 

--- a/src/features/detail/DetailContent.jsx
+++ b/src/features/detail/DetailContent.jsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router";
-import { useEffect, useRef } from "react"; // useRef 추가
+import { useEffect, useRef } from "react"; 
 import useLinkUpStore from "../../shared/store/store";
 import CustomButton from "../../package/customButton/CustomButton.jsx";
 import Modal from "../../package/modal/Modal.jsx";
@@ -35,10 +35,10 @@ const DetailContent = () => {
     const modalKey = useLinkUpStore((state) => state.modalKey);
     const setModalKey = useLinkUpStore((state) => state.setModalKey);
 
-    const isSubscribed = artistArray.some((a) => a.artist_id === Number(id));
+    const isSubscribed = artistArray.some((a) => a.id === Number(id));
 
-    const currentArtist = artistArray.find((a) => a.artist_id === Number(id));
-    const imageUrl = currentArtist?.banner_url;
+    const currentArtist = artistArray.find((a) => a.id === Number(id));
+    const imageUrl = currentArtist?.banner_url || currentArtist?.artist_image_url;
 
     const scrollRef = useRef(null);
 

--- a/src/features/detail/DetailContent.jsx
+++ b/src/features/detail/DetailContent.jsx
@@ -103,7 +103,6 @@ const DetailContent = () => {
                         <CustomImageIcon
                             key={artistItem.artist_id}
                             url={artistItem.artist_image_url}
-                            className={styles.circleIcon}
                             onClick={() => navigate(`/detail/artist/${artistItem.artist_id}`)}
                         />
                     ))}

--- a/src/features/detail/DetailContent.module.css
+++ b/src/features/detail/DetailContent.module.css
@@ -26,12 +26,6 @@
 }
 
 .circleIcon {
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    object-fit: cover;
-    cursor: pointer;
-    flex-shrink: 0;
 }
 
 .arrow {

--- a/src/shared/CustomImageIcon/CustomImageIcon.jsx
+++ b/src/shared/CustomImageIcon/CustomImageIcon.jsx
@@ -1,7 +1,7 @@
 import CustomImage from "../../package/customImage/CustomImage.jsx";
 
 const CustomImageIcon = ({ url, ...props }) => {
-  return <CustomImage {...props} url={url} height="MD" shape="CIRCLE"  />;
+  return <CustomImage {...props} url={url} height="xs" shape="CIRCLE"  />;
 };
 
 export default CustomImageIcon;

--- a/src/shared/FanPostGrid.jsx
+++ b/src/shared/FanPostGrid.jsx
@@ -65,7 +65,7 @@ const FanPostGrid = ({ fanPostArray, isMine, isBlurred = true }) => {
         <GridCardContainer>
             {isMine && <AddCard />}
             {fanPostArray.map((fanPost) => (
-                <FanPostCard fanPost={fanPost} isBlurred={isBlurred} />
+                <FanPostCard key={fanPost.id} fanPost={fanPost} isBlurred={isBlurred} />
             ))}
         </GridCardContainer>
     );


### PR DESCRIPTION
## 스크린샷
<img width="1642" height="1446" alt="image" src="https://github.com/user-attachments/assets/c752f029-b911-4f82-bdfd-4d9ac1471162" />
<img width="1606" height="1414" alt="image" src="https://github.com/user-attachments/assets/d3f4bb54-3e68-47ba-880f-9fca0dff5e3e" />

## 📝작업 내용
> 배너에 아티스트 이미지가 정상적으로 연결
> 팬 포스트 클릭 시 팬포스트 모달창으로 이동 
> 구독 버튼은 색상 차이 없이 통일