### PR TITLE
#296 로그아웃 시 로그아웃 api 호출

### DIFF
--- a/src/shared/services/useAuth.js
+++ b/src/shared/services/useAuth.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { apiAuthLogin } from "./linkupApi";
@@ -75,13 +75,22 @@ const useAuthLogout = () => {
     const setUser = useLinkUpStore((state) => state.setUser);
     const setArtistArray = useLinkUpStore((state) => state.setArtistArray);
 
-    const logout = useCallback(() => {
-        queryClient.setQueryData(["/api/auth/me"], null);
-        queryClient.setQueryData(["/api/subscriptions"], []);
+    const logoutMutation = useMutation({
+        mutationFn: () => axiosReturnsData("POST", "/api/auth/logout"),
+        onMutate: () => {
+            queryClient.setQueryData(["/api/auth/me"], null);
+            queryClient.setQueryData(["/api/subscriptions"], []);
 
-        setAccessToken(null);
-        setUser(null);
-        setArtistArray([]);
+            setUser(null);
+            setArtistArray([]);
+        },
+        onSettled: () => {
+            setAccessToken(null);
+        },
+    });
+
+    const logout = useCallback(() => {
+        logoutMutation.mutate();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷
<img width="813" height="396" alt="image" src="https://github.com/user-attachments/assets/bcbee05e-94a6-4d36-b7dd-e52f38b59202" />


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. `useAuth`에 `logoutMutation` 제작
2. 로그아웃 요청 보낼 때까지는 토큰이 남아있게 스토어 초기화 순서 정함