### PR TITLE
#330 달력__이번 달이 아닌 달의 일정은 event box 배경 흐리게

### DIFF
--- a/src/package/calendar/_DateCell.jsx
+++ b/src/package/calendar/_DateCell.jsx
@@ -85,16 +85,16 @@ const DayCircle = ({ date, isHolyday, isToday, isDim }) => {
     );
 };
 
-const EventBoxMany = ({ eventArray }) => {
+const EventBoxMany = ({ eventArray, isDim }) => {
     return (
         <>
             {eventArray.map((event) => (
-                <EventBox key={event.id} event={event} />
+                <EventBox key={event.id} event={event} isDim={isDim} />
             ))}
         </>
     );
 };
-const EventDotMany = ({ eventArray }) => {
+const EventDotMany = ({ eventArray, isDim }) => {
     const isTooMuch = eventArray.length > 4;
     if (isTooMuch) {
         return <EventDot />;
@@ -102,7 +102,7 @@ const EventDotMany = ({ eventArray }) => {
     return (
         <Hstack gap="xs">
             {eventArray.map((event) => (
-                <EventDot key={event.id} />
+                <EventDot key={event.id} isDim={isDim} />
             ))}
         </Hstack>
     );
@@ -123,9 +123,9 @@ const DateCell = ({ date, eventArray, isDim, isToday }) => {
     return (
         <Vstack onDoubleClick={handleDoubleClick}>
             <DayCircle isDim={isDim} date={date} isHolyday={isHolyday} isToday={isToday} />
-            {size === "lg" && <EventBoxMany eventArray={eventArray} />}
+            {size === "lg" && <EventBoxMany isDim={isDim} eventArray={eventArray} />}
             <div className={styles.eventDotContainer}>
-                {size === "md" && <EventDotMany eventArray={eventArray} />}
+                {size === "md" && <EventDotMany isDim={isDim} eventArray={eventArray} />}
             </div>
         </Vstack>
     );

--- a/src/package/calendar/_EventBox.jsx
+++ b/src/package/calendar/_EventBox.jsx
@@ -1,11 +1,14 @@
-import styles from "./calendar.module.css";
+import styles from "./_EventBox.module.css";
 import { useCalendarContext } from "./CalendarContext";
 
-export const EventDot = () => {
-    return <div className={styles.eventDot} />;
+export const EventDot = ({ isDim }) => {
+    const styleForVar = {};
+    styleForVar["--bg"] = isDim ? "var(--color-muted)" : "var(--color-vivid)";
+
+    return <div style={styleForVar} className={styles.eventDot} />;
 };
 
-const EventBox = ({ event }) => {
+const EventBox = ({ event, isDim }) => {
     const { setModalKey, setSelectedEvent } = useCalendarContext();
     const { id, start_time, end_time, title, subjectId, subjectName } = event;
 
@@ -18,8 +21,17 @@ const EventBox = ({ event }) => {
         setSelectedEvent(event);
         setModalKey("agencyCalendar");
     };
+
+    const styleForVar = {};
+    styleForVar["--bg"] = isDim ? "var(--color-muted)" : "var(--color-vivid)";
+
     return (
-        <div className={styles.eventBox} onClick={handleClick} onDoubleClick={handleDoubleClick}>
+        <div
+            style={styleForVar}
+            className={styles.eventBox}
+            onClick={handleClick}
+            onDoubleClick={handleDoubleClick}
+        >
             {title}
         </div>
     );

--- a/src/package/calendar/_EventBox.module.css
+++ b/src/package/calendar/_EventBox.module.css
@@ -1,0 +1,12 @@
+.eventBox {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--rounded-md);
+    background-color: var(--bg);
+    color: var(--color-vivid-inverted);
+}
+
+.eventDot {
+    background-color: var(--bg);
+    padding: var(--spacing-xs);
+    border-radius: var(--rounded-full);
+}

--- a/src/package/calendar/calendar.module.css
+++ b/src/package/calendar/calendar.module.css
@@ -7,16 +7,3 @@
 .bold {
     font-weight: var(--font-weight-semibold);
 }
-
-.eventBox {
-    padding: var(--spacing-xs) var(--spacing-sm);
-    border-radius: var(--rounded-md);
-    background-color: var(--color-vivid);
-    color: var(--color-vivid-inverted);
-}
-
-.eventDot {
-    background-color: var(--color-vivid);
-    padding: var(--spacing-xs);
-    border-radius: var(--rounded-full);
-}


### PR DESCRIPTION
**제목 템플릿**

> #{이슈 번호} {이슈 제목}

## 스크린샷

<img width="1213" height="622" alt="image" src="https://github.com/user-attachments/assets/27959b26-d633-4429-a2cd-fe81a345ba1a" />


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 이전, 다음달의 일정은 흐리게 표시
